### PR TITLE
Required changes to upgrade the base-image to Debian 10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:latest
 
 MAINTAINER MarvAmBass (https://github.com/DesktopContainers)
 
@@ -15,6 +15,7 @@ RUN apt-get -q -y update \
                           tigervnc-standalone-server \
                           \
                           mate-desktop-environment \
+                          firefox-esr \
                           tmux \
  && apt-get -q -y clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get -q -y update \
  && apt-get -q -y install runit \
                           rsyslog \
                           wget \
+                          nano \
                           python \
                           python-numpy \
                           \

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Debian VNC/Websockify/SSH Desktopcontainers Base Image
 
-A dockerfile that builds debian stretch with VNC, websockify and ssh Server.
+A dockerfile that builds debian latest with VNC, websockify and ssh Server and firefox-esr
 
 This is build as base image for various desktop applications.
 
 The applications will be available as VNC, Websockify VNC, Web (noVNC), SSH or Host X11.
 You can change the behaviour via environment variables. So the User can decide how he wants to use the application.
 
-Base image: _/debian:stretch_
-Because I want a base system which runs nearly anything and everywhere.
+Base image: _/debian:latest_
+Because I want an up to date base system which runs nearly anything and everywhere.
 
 # Environment variables and defaults
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -115,7 +115,7 @@ EOF
   echo -e '#!/bin/sh\nexec /usr/sbin/rsyslogd -n' > /etc/sv/rsyslog/run
     echo -e '#!/bin/sh\nrm /var/run/rsyslogd.pid' > /etc/sv/rsyslog/finish
 	echo -e "#!/bin/sh\nexec /usr/sbin/sshd -D" > /etc/sv/sshd/run
-	echo -e "#!/bin/sh\nrm -rif /tmp/.X*\nexec /bin/su -s /bin/sh -c \"vncserver :1 -SecurityTypes none -depth 24 -fg --I-KNOW-THIS-IS-INSECURE\" app" > /etc/sv/tigervnc/run
+	echo -e "#!/bin/sh\nrm -rif /tmp/.X*\nexec /bin/su -s /bin/sh -c \"vncserver :1 -SecurityTypes none -depth 24 -fg -localhost no --I-KNOW-THIS-IS-INSECURE\" app" > /etc/sv/tigervnc/run
   echo -e "#!/bin/sh\nexec /opt/websockify/run 443 --web /opt/novnc/ --ssl-only --cert /config/ssl-cert.crt --key /config/ssl-cert.key localhost:5901" > /etc/sv/websockify-ssl/run
   echo -e "#!/bin/sh\nexec /opt/websockify/run 80 --web /opt/novnc/ localhost:5901" > /etc/sv/websockify/run
   chmod a+x /etc/sv/*/run /etc/sv/*/finish

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -106,13 +106,16 @@ EOF
 	###
   # RUNIT
   ###
-
+  #
+  # Added cleanup below when starting vncserver to work round
+  # issue when restarting a container and vncserver does not close cleanly
+  #
   echo ">> RUNIT - create services"
   mkdir -p /etc/sv/rsyslog /etc/sv/sshd /etc/sv/tigervnc /etc/sv/websockify /etc/sv/websockify-ssl
   echo -e '#!/bin/sh\nexec /usr/sbin/rsyslogd -n' > /etc/sv/rsyslog/run
     echo -e '#!/bin/sh\nrm /var/run/rsyslogd.pid' > /etc/sv/rsyslog/finish
 	echo -e "#!/bin/sh\nexec /usr/sbin/sshd -D" > /etc/sv/sshd/run
-	echo -e "#!/bin/sh\nexec /bin/su -s /bin/sh -c \"vncserver :1 -SecurityTypes none -depth 24 -fg --I-KNOW-THIS-IS-INSECURE\" app" > /etc/sv/tigervnc/run
+	echo -e "#!/bin/sh\nrm -rif /tmp/.X*\nexec /bin/su -s /bin/sh -c \"vncserver :1 -SecurityTypes none -depth 24 -fg --I-KNOW-THIS-IS-INSECURE\" app" > /etc/sv/tigervnc/run
   echo -e "#!/bin/sh\nexec /opt/websockify/run 443 --web /opt/novnc/ --ssl-only --cert /config/ssl-cert.crt --key /config/ssl-cert.key localhost:5901" > /etc/sv/websockify-ssl/run
   echo -e "#!/bin/sh\nexec /opt/websockify/run 80 --web /opt/novnc/ localhost:5901" > /etc/sv/websockify/run
   chmod a+x /etc/sv/*/run /etc/sv/*/finish


### PR DESCRIPTION
Adds nano and Firefox-ESR, which may not be required for the base image.

Updates the desktop icons for Debian10 and makes sure they are executable so that the icons show up correctly.

Fixes a problem I experienced when restarting, not recreating, an existing container, in that the VNC Server does not terminate cleanly, so I added in the necessary commands to remove the leftover pid and session files, the same way vnc would if it were allowed to terminate cleanly.

Also, I noticed that in Debian 10, the way vncserver seems to work slightly differently, it was not picking up the localhost=no directive from vnc.conf, so I added this into the entrypoint script that writes the script that starts vnc so that it is explicitly defined at run-time